### PR TITLE
Add support for other response types

### DIFF
--- a/src/Concerns/TracesHttpRequests.php
+++ b/src/Concerns/TracesHttpRequests.php
@@ -2,11 +2,8 @@
 
 namespace PlunkettScott\LaravelOpenTelemetry\Concerns;
 
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Str;
-use Illuminate\View\View;
 use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\API\Trace\SpanKind;

--- a/src/Http/Middleware/TraceMiddleware.php
+++ b/src/Http/Middleware/TraceMiddleware.php
@@ -4,10 +4,7 @@ namespace PlunkettScott\LaravelOpenTelemetry\Http\Middleware;
 
 use Closure;
 use Exception;
-use Illuminate\Contracts\View\View;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 use PlunkettScott\LaravelOpenTelemetry\Concerns;

--- a/src/Http/Middleware/TraceMiddleware.php
+++ b/src/Http/Middleware/TraceMiddleware.php
@@ -4,6 +4,8 @@ namespace PlunkettScott\LaravelOpenTelemetry\Http\Middleware;
 
 use Closure;
 use Exception;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use OpenTelemetry\API\Trace\TracerInterface;
@@ -51,7 +53,7 @@ class TraceMiddleware
         return $response;
     }
 
-    public function terminate(Request $request, Response $response): void
+    public function terminate(Request $request, mixed $response): void
     {
         $this->terminateRootSpan($request, $response);
     }


### PR DESCRIPTION
This PR adds support for response types other than the `Illuminate\Http\Response` type.