### PR TITLE
Add CI for Laravel 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2]
-        laravel: [10]
+        laravel: [9, 10]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5",
         "laravel/pint": "^1.6",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-mock": "^2.0",
         "phpstan/phpstan": "^1.10",


### PR DESCRIPTION
Enabled running pest tests against both Laravel 9 and Laravel 10